### PR TITLE
Make Junos timeout configurable

### DIFF
--- a/napalm/junos.py
+++ b/napalm/junos.py
@@ -27,16 +27,17 @@ from utils import string_parsers
 
 class JunOSDriver(NetworkDriver):
 
-    def __init__(self, hostname, username, password):
+    def __init__(self, hostname, username, password, timeout=60):
         self.hostname = hostname
         self.username = username
         self.password = password
+        self.timeout = timeout
         self.device = Device(hostname, user=username, password=password)
         self.config_replace = False
 
     def open(self):
         self.device.open()
-        self.device.timeout = 60        
+        self.device.timeout = self.timeout
         self.device.bind(cu=Config)
         self.device.cu.lock()
 


### PR DESCRIPTION
We have SRX clusters that take a long time to commit (~90+ seconds).  This change, along with host variables in ansible and some tweaks to napalm_install_config let us override the timeout on a per-host basis.  

This would make the arguments for the Junos driver different than the other drivers, which might be a bit ugly, though nothing should break since there's a 60 second default.

I haven't included the napalm_install_config changes here, since they always send a timeout argument...which won't work for anything other than this Junos driver.  (We're only using NAPALM for Junos at the moment).