### PR TITLE
Module for IBM/Lenovo RackSwitch series.

### DIFF
--- a/docs/ibm.rst
+++ b/docs/ibm.rst
@@ -1,0 +1,13 @@
+IBM Networking Operating System
+-------
+
+Rollback
+~~~~~~~~
+
+Rollback is simply implemented by reading current running configuration before any load actions. Rollback function executes load replace and commit.
+
+
+Atomic Changes
+~~~~~~~~~~~~~~
+
+IBM plugin uses netconf to load configuration on to device. It seems that configuration is executed line by line but we can be sure that all lines will be executed. There are three options for error handling: stop-on-error, continue-on-error and rollback-on-error. Plugin uses rollback-on-error option in case of merge operation. However replace operation uses continue-on-error option. In case of typo in configuration, device will inform plugin about error but execute all the rest lines. Plugin will revert configuration using rollback function from the plugin. I do not use rollback-on-error for replace operation because in case of error device is left without any configuration. It seems like a bug. It will be investigated further. Moreover it seems that replace option wipe out whole configuration on device at the first step, so this option is good for provisioning of new device and it is not recomended for device in production.

--- a/napalm/ibm.py
+++ b/napalm/ibm.py
@@ -1,0 +1,143 @@
+#
+# Copyright 2015 Kamil Derynski, Opera Software ASA
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+from base import NetworkDriver
+from exceptions import ReplaceConfigException, MergeConfigException
+from bnclient import bnclient
+import difflib
+import sys
+from StringIO import StringIO
+
+
+class IBMDriver(NetworkDriver):
+
+    def __init__(self, hostname, username, password, timeout=60):
+        self.hostname = hostname
+        self.username = username
+        self.password = password
+        self.timeout = timeout
+        self.argv = ['', '-u', username, '-p', password, hostname]
+        self.bnc = bnclient.bnclient(self.argv)
+        self.config_replace = False
+        self.config = {"running": "", "candidate": "", "rollback": ""}
+        self.filename_running = "/tmp/" + hostname + "-running.conf"
+        self.filename_candidate = None
+        self.filename_rollback = "/tmp/" + hostname + "-rollback.conf"
+        self.error = StringIO()
+
+    def str2argv(self, str=''):
+        return str.split(' ')
+
+    def open(self):
+        self.bnc.connect()
+        self.bnc.sendhello()
+        self._get_config(self.filename_rollback)
+
+    def close(self):
+        self.bnc.close()
+
+    def _bnc_cmd(self, file, operation, error_option):
+        cmd = "-o edit-config -t running -f "
+        cmd += file
+        cmd += " -d " + operation
+        cmd += " -r " + error_option
+        return cmd
+
+    def _write_memory(self):
+        cmd = "-o copy-config -t startup -s running"
+        return cmd
+
+    def _send_rpc(self, cmd):
+        self.error = StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = self.error
+        self.bnc.sendrpc(self.str2argv(cmd))
+        sys.stdout = old_stdout
+
+    def _get_config(self, filename):
+        self.bnc.sendrpc(self.str2argv("-o get -f " + filename))
+
+    def _load_config(self, filename, config):
+        self._get_config(self.filename_rollback)
+        if filename is None:
+            configuration = config
+        else:
+            with open(filename) as f:
+                configuration = f.read()
+                self.config['candidate'] = configuration
+                self.filename_candidate = filename
+                f.close()
+
+    def load_replace_candidate(self, filename=None, config=None):
+        self.config_replace = True
+        self._load_config(filename, config)
+
+    def load_merge_candidate(self, filename=None, config=None):
+        self.config_replace = False
+        self._load_config(filename, config)
+
+    def compare_config(self):
+        result = ''
+        if self.config_replace:
+            self._get_config(self.filename_running)
+            with open(self.filename_running, 'r') as running:
+                with open(self.filename_candidate, 'r') as candidate:
+                    diff = difflib.unified_diff(
+                        running.readlines(),
+                        candidate.readlines(),
+                        fromfile='running',
+                        tofile='candidate',
+                    )
+            for line in diff:
+                for prefix in ('---', '+++', '@@'):
+                    if line.startswith(prefix):
+                        break
+                else:
+                    result += line
+        else:
+            result = self.config['candidate']
+        return str(result).strip()
+
+    def _commit_replace(self):
+        cmd = self._bnc_cmd(self.filename_candidate, "replace", "continue-on-error")
+        self._send_rpc(cmd)
+        if self.error.getvalue():
+            self.rollback()
+            raise ReplaceConfigException(self.error.getvalue())
+
+    def _commit_merge(self):
+        cmd = self._bnc_cmd(self.filename_candidate, "merge", "rollback-on-error")
+        self._send_rpc(cmd)
+        if self.error.getvalue():
+            self.discard_config()
+            raise MergeConfigException(self.error.getvalue())
+
+    def commit_config(self):
+        if self.config_replace:
+            self._commit_replace()
+        else:
+            self._commit_merge()
+        cmd = self._write_memory()
+        self._send_rpc(cmd)
+
+    def discard_config(self):
+        self.filename_candidate = self.filename_running
+        self.config['candidate'] = self.config['running']
+
+    def rollback(self):
+        cmd = self._bnc_cmd(self.filename_rollback, "replace", "rollback-on-error")
+        self._send_rpc(cmd)
+        cmd = self._write_memory()
+        self._send_rpc(cmd)

--- a/test/unit/TestIBMDriver.py
+++ b/test/unit/TestIBMDriver.py
@@ -12,25 +12,22 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-from eos import EOSDriver
-from iosxr import IOSXRDriver
-from junos import JunOSDriver
-from fortios import FortiOSDriver
-from ibm import IBMDriver
+import unittest
 
-def get_network_driver(vendor):
-    driver_mapping = {
-        'EOS': EOSDriver,
-        'ARISTA': EOSDriver,
-        'IOS-XR': IOSXRDriver,
-        'IOSXR': IOSXRDriver,
-        'JUNOS': JunOSDriver,
-        'JUNIPER': JunOSDriver,
-        'FORTIOS': FortiOSDriver,
-        'IBM': IBMDriver,
-    }
-    try:
-        return driver_mapping[vendor.upper()]
-    except KeyError:
-        raise Exception('Vendor/OS not supported: %s' % vendor)
+from napalm.ibm import IBMDriver
+from base import TestNetworkDriver
 
+
+class TestIBMDriver(unittest.TestCase, TestNetworkDriver):
+
+    @classmethod
+    def setUpClass(cls):
+        hostname = '10.20.18.253'
+        username = 'admin'
+        password = 'admin'
+        cls.vendor = 'ibm'
+
+        cls.device = IBMDriver(hostname, username, password, timeout=60)
+        cls.device.open()
+        cls.device.load_replace_candidate(filename='%s/initial.conf' % cls.vendor)
+        cls.device.commit_config()

--- a/test/unit/base.py
+++ b/test/unit/base.py
@@ -13,8 +13,11 @@
 # the License.
 
 from napalm import exceptions
+import difflib
+import models
 
 class TestNetworkDriver:
+
 
     @classmethod
     def tearDownClass(cls):
@@ -25,7 +28,12 @@ class TestNetworkDriver:
     @staticmethod
     def read_file(filename):
         with open(filename, 'r') as f:
-            return f.read()
+            return f.read().strip()
+
+    @staticmethod
+    def print_diff_strings(orig, new):
+        for line in difflib.context_diff(orig.splitlines(), new.splitlines()):
+            print line
 
     def test_replacing_and_committing_config(self):
         self.device.load_replace_candidate(filename='%s/new_good.conf' % self.vendor)
@@ -48,6 +56,7 @@ class TestNetworkDriver:
         except exceptions.ReplaceConfigException:
             self.device.load_replace_candidate(filename='%s/initial.conf' % self.vendor)
             diff = self.device.compare_config()
+            self.device.discard_config()
             result = True and len(diff) == 0
         self.assertTrue(result)
 
@@ -58,6 +67,7 @@ class TestNetworkDriver:
         commit_diff = self.device.compare_config()
         self.device.discard_config()
         discard_diff = self.device.compare_config()
+        self.device.discard_config()
 
         result = (commit_diff == intended_diff) and (discard_diff == '')
         self.assertTrue(result)
@@ -97,29 +107,51 @@ class TestNetworkDriver:
         result = False
         try:
             self.device.load_merge_candidate(filename='%s/merge_typo.conf' % self.vendor)
-            diff = self.device.compare_config()
             self.device.commit_config()
+            raise Exception("We shouldn't be here")
         except exceptions.MergeConfigException:
             # We load the original config as candidate. If the commit failed cleanly the compare_config should be empty
             self.device.load_replace_candidate(filename='%s/initial.conf' % self.vendor)
             result = self.device.compare_config() == ''
+            self.device.discard_config()
 
         self.assertTrue(result)
 
-    '''
+    @staticmethod
+    def _test_model(model, data):
+        same_keys = set(model.keys()) == set(data.keys())
+
+        if not same_keys:
+            print "model_keys: {}\ndata_keys: {}".format(model.keys(), data.keys())
+
+        correct_class = True
+        for key, instance_class in model.iteritems():
+            same_class = isinstance(data[key], instance_class)
+            correct_class = correct_class and same_class
+
+            if not same_class:
+                print "key: {}\nmodel_class: {}\ndata_class: {}".format(key, instance_class, data[key].__class__)
+
+        return correct_class and same_keys
+
     def test_get_facts(self):
-        intended_facts = {
-            'vendor': unicode,
-            'model': unicode,
-            'os_version': unicode,
-            'serial_number': unicode,
-            'uptime': float,
-            'interface_list': list
-        }
-        facts_dictionary = dict()
+        facts = self.device.get_facts()
+        result = self._test_model(models.facts, facts)
+        self.assertTrue(result)
 
-        for fact, value in self.device.get_facts().iteritems():
-            facts_dictionary[fact] = value.__class__
+    def test_get_interfaces(self):
+        result = True
 
-        self.assertEqual(facts_dictionary, intended_facts)
-    '''
+        for interface, interface_data in self.device.get_interfaces().iteritems():
+            result = result and self._test_model(models.interface, interface_data)
+
+        self.assertTrue(result)
+
+    def test_get_lldp_neighbors(self):
+        result = True
+
+        for interface, neighbor_list in self.device.get_lldp_neighbors().iteritems():
+            for neighbor in neighbor_list:
+                result = result and self._test_model(models.lldp_neighbors, neighbor)
+
+        self.assertTrue(result)

--- a/test/unit/ibm/initial.conf
+++ b/test/unit/ibm/initial.conf
@@ -1,0 +1,50 @@
+version "7.11.2"
+switch-type "IBM Networking Operating System RackSwitch G8052"
+iscli-new
+!
+!
+
+!
+!
+!
+no system dhcp
+no system default-ip
+hostname "test-sw2"
+!
+!
+interface port XGE2
+	description "port 50 uplink"
+	switchport mode trunk
+	exit
+!
+vlan 18
+	name "sysadmin"
+!
+!
+spanning-tree stp 18 vlan 18
+!
+!
+!
+!
+!
+!
+!
+interface ip 18
+	ip address 10.20.18.253 255.255.255.0
+	vlan 18
+	enable
+	exit
+!
+ip gateway 1 address 10.20.18.1
+ip gateway 1 enable
+!
+!
+!
+!
+!
+!
+!
+!
+!
+end
+

--- a/test/unit/ibm/merge_good.conf
+++ b/test/unit/ibm/merge_good.conf
@@ -1,0 +1,15 @@
+interface port 1
+    description "test description"
+    switchport mode trunk
+    switchport trunk allowed vlan 27,2000
+    switchport trunk native vlan 27
+    spanning-tree portfast
+    exit
+!
+
+vlan 27
+    name "install"
+!
+vlan 2000
+    name "another test"
+!

--- a/test/unit/ibm/merge_good.diff
+++ b/test/unit/ibm/merge_good.diff
@@ -1,0 +1,33 @@
+hostname "test-sw2"
+ !
+ !
+-interface port 1
+-	description "test description"
+-	switchport mode trunk
+-	switchport trunk allowed vlan 27,2000
+-	switchport trunk native vlan 27
+-	spanning-tree portfast
+-	exit
+-!
+ interface port XGE2
+ 	description "port 50 uplink"
+ 	switchport mode trunk
+ vlan 18
+ 	name "sysadmin"
+ !
+-vlan 27
+-	name "install"
+-!
+-vlan 2000
+-	name "another test"
+-!
+-!
+ !
+ spanning-tree stp 18 vlan 18
+-!
+-spanning-tree stp 27 vlan 27
+-!
+-spanning-tree stp 95 vlan 2000
+ !
+ !
+ !

--- a/test/unit/ibm/merge_typo.conf
+++ b/test/unit/ibm/merge_typo.conf
@@ -1,0 +1,15 @@
+inrface port 1
+    description "test description"
+    switchport mode trunk
+    switchport trunk allowed vlan 27,2000
+    switchport trunk native vlan 27
+    spanning-tree portfast
+    exit
+!
+
+vlan 27
+    name "install"
+!
+vlan 2000
+    name "another test"
+!

--- a/test/unit/ibm/new_good.conf
+++ b/test/unit/ibm/new_good.conf
@@ -1,0 +1,69 @@
+version "7.11.2"
+switch-type "IBM Networking Operating System RackSwitch G8052"
+iscli-new
+!
+!
+
+!
+!
+!
+no system dhcp
+no system default-ip
+hostname "test-sw2"
+!
+!
+interface port 1
+	description "test description"
+	switchport mode trunk
+	switchport trunk allowed vlan 27,2000
+	switchport trunk native vlan 27
+	spanning-tree portfast
+	exit
+!
+interface port XGE2
+	description "port 50 uplink"
+	switchport mode trunk
+	exit
+!
+vlan 18
+	name "sysadmin"
+!
+vlan 27
+	name "install"
+!
+vlan 2000
+	name "another test"
+!
+!
+!
+spanning-tree stp 18 vlan 18
+!
+spanning-tree stp 27 vlan 27
+!
+spanning-tree stp 95 vlan 2000
+!
+!
+!
+!
+!
+!
+!
+interface ip 18
+	ip address 10.20.18.253 255.255.255.0
+	vlan 18
+	enable
+	exit
+!
+ip gateway 1 address 10.20.18.1
+ip gateway 1 enable
+!
+!
+!
+!
+!
+!
+!
+!
+!
+end
+

--- a/test/unit/ibm/new_good.diff
+++ b/test/unit/ibm/new_good.diff
@@ -1,0 +1,33 @@
+ hostname "test-sw2"
+ !
+ !
++interface port 1
++	description "test description"
++	switchport mode trunk
++	switchport trunk allowed vlan 27,2000
++	switchport trunk native vlan 27
++	spanning-tree portfast
++	exit
++!
+ interface port XGE2
+ 	description "port 50 uplink"
+ 	switchport mode trunk
+ vlan 18
+ 	name "sysadmin"
+ !
++vlan 27
++	name "install"
++!
++vlan 2000
++	name "another test"
++!
++!
+ !
+ spanning-tree stp 18 vlan 18
++!
++spanning-tree stp 27 vlan 27
++!
++spanning-tree stp 95 vlan 2000
+ !
+ !
+ !

--- a/test/unit/ibm/new_typo.conf
+++ b/test/unit/ibm/new_typo.conf
@@ -1,0 +1,69 @@
+version "7.11.2"
+switch-type "IBM Networking Operating System RackSwitch G8052"
+iscli-new
+!
+!
+
+!
+!
+!
+no system dhcp
+no system default-ip
+histname "test-sw2"
+!
+!
+interface port 1
+	description "test description"
+	switchport mode trunk
+	switchport trunk allowed vlan 27,2000
+	switchport trunk native vlan 27
+	spanning-tree portfast
+	exit
+!
+interface port XGE2
+	description "port 50 uplink"
+	switchport mode trunk
+	exit
+!
+vlan 18
+	name "sysadmin"
+!
+vlan 27
+	name "install"
+!
+vlan 2000
+	name "another test"
+!
+!
+!
+spanning-tree stp 18 vlan 18
+!
+spanning-tree stp 27 vlan 27
+!
+spanning-tree stp 95 vlan 2000
+!
+!
+!
+!
+!
+!
+!
+interface ip 18
+	ip address 10.20.18.253 255.255.255.0
+	vlan 18
+	enable
+	exit
+!
+ip gateway 1 address 10.20.18.1
+ip gateway 1 enable
+!
+!
+!
+!
+!
+!
+!
+!
+!
+end
+


### PR DESCRIPTION
This is the first version of module for IBM/Lenovo RackSwitch series. It uses netconf via library provided by Lenovo (mentioned in official manual). Module supports only configuration management features for now. There are couple of issues with netconf implementation on these devices and it will be described in documentation. Unit tests have been performed. Obviously there are 3 errors (getters are not implemented yet) and 1 error for "test_merge_configuration_typo_and_rollback". I can detect syntax error only during commit operations. I do not have problem with "test_replacing_config_with_typo" because commit statement is under "try" in this test. Maybe it should be under "try" also in case of merge ?
I am open for discussion :)