### PR TITLE
timeout implemented in IBM module

### DIFF
--- a/napalm/ibm.py
+++ b/napalm/ibm.py
@@ -41,7 +41,7 @@ class IBMDriver(NetworkDriver):
         return str.split(' ')
 
     def open(self):
-        self.bnc.connect()
+        self.bnc.connect(self.timeout)
         self.bnc.sendhello()
         self._get_config(self.filename_rollback)
 


### PR DESCRIPTION
I have added timeout parameter to bnclient library, so now it can be used in napalm module for IBM/Lenovo devices. It solves #77 bug :)